### PR TITLE
Fix missing sigma/dof statistics in MarketAdjusted and ComparisonPeriodMeanAdjusted models

### DIFF
--- a/R/models.R
+++ b/R/models.R
@@ -258,8 +258,12 @@ MarketAdjustedModel <- R6Class("MarketAdjustedModel",
                                    private$add_residuals(residuals)
                                    private$first_order_autocorrelation(residuals)
 
-                                   # forecast correction term
+                                   # sigma and degree of freedom (needed by test statistics)
                                    sigma = sd(residuals)
+                                   private$.statistics$sigma = sigma
+                                   private$.statistics$degree_of_freedom = length(residuals) - 1
+
+                                   # forecast correction term
                                    event_window_tbl = data_tbl %>% filter(event_window == 1)
                                    event_market_returns = event_window_tbl$index_returns
                                    estimation_window_length = nrow(estimation_tbl)
@@ -327,8 +331,12 @@ ComparisonPeriodMeanAdjustedModel <- R6Class("ComparisonPeriodMeanAdjustedModel"
                                                  private$add_residuals(residuals)
                                                  private$first_order_autocorrelation(residuals)
 
-                                                 # forecast correction term
+                                                 # sigma and degree of freedom (needed by test statistics)
                                                  sigma = sd(residuals)
+                                                 private$.statistics$sigma = sigma
+                                                 private$.statistics$degree_of_freedom = length(residuals) - 1
+
+                                                 # forecast correction term
                                                  event_window_tbl = data_tbl %>% filter(event_window == 1)
                                                  event_market_returns = event_window_tbl$index_returns
                                                  estimation_window_length = nrow(estimation_tbl)


### PR DESCRIPTION
## Summary

- Fix `MarketAdjustedModel` and `ComparisonPeriodMeanAdjustedModel` crashing when used with test statistics (`ARTTest`, `CARTTest`, `CSectT`)
- Both models computed `sigma` locally but never stored it in `private$.statistics$sigma` or set `degree_of_freedom`, causing `NULL` (length 0) errors in downstream test statistics
- Store both values in `private$.statistics`, matching the pattern used by all other models

Fixes #1

## Test plan

- [x] Verified `MarketAdjustedModel` completes full `run_event_study()` pipeline
- [x] Verified `ComparisonPeriodMeanAdjustedModel` completes full `run_event_study()` pipeline
- [x] Verified all other models (`MarketModel`, `BHARModel`, `VolatilityModel`, `LinearFactorModel`, `FamaFrench3FactorModel`, `FamaFrench5FactorModel`, `Carhart4FactorModel`) still work correctly
- [ ] `R CMD check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)