### PR TITLE
Fix many-to-many join inflating BMP/Patell/KP statistics (GH #7)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # EventStudy 0.40.0
 
+## Bug Fixes
+
+* `BMPTest`, `KolariPynnonenTest`, and `PatellZTest` joined the per-event
+  model (sigma / forecast-error-corrected sigma) on `firm_symbol` instead of
+  `event_id`. When a firm appeared in more than one event this produced a
+  many-to-many join that duplicated rows, inflating `n_events` and the test
+  statistics (`bmp_t`, `kp_t`, `aar_z`). The joins and per-event groupings now
+  key on `event_id` (GH #7).
+
 ## New Features
 
 * 13 return models: Market Model, Market Adjusted, Comparison Period Mean

--- a/R/multi_event_test_statistics.R
+++ b/R/multi_event_test_statistics.R
@@ -100,9 +100,12 @@ PatellZTest <- R6Class("PatellZTest",
                           # Use median k across firms (should be same for all)
                           k_param <- stats::median(model_k$k)
 
+                          # Key all per-event quantities on event_id, not
+                          # firm_symbol: each event is fit separately and a firm
+                          # may recur across events.
                           sd_asar = data_tbl %>%
                             dplyr::filter(estimation_window == 1) %>%
-                            dplyr::group_by(firm_symbol) %>%
+                            dplyr::group_by(event_id) %>%
                             dplyr::summarise(m = dplyr::n(), .groups = "drop") %>%
                             dplyr::mutate(
                               Q_i = ifelse(
@@ -118,19 +121,19 @@ PatellZTest <- R6Class("PatellZTest",
                               fec <- x$statistics$forecast_error_corrected_sigma
                               if (is.null(fec)) NA_real_ else fec
                             })) %>%
-                            dplyr::select(firm_symbol, fec_sigma) %>%
+                            dplyr::select(event_id, fec_sigma) %>%
                             tidyr::unnest(fec_sigma) %>%
-                            dplyr::group_by(firm_symbol) %>%
+                            dplyr::group_by(event_id) %>%
                             dplyr::mutate(day_index = dplyr::row_number()) %>%
                             dplyr::ungroup()
 
                           # Standardize abnormal returns by forecast-error-corrected sigma
                           aar_caar_stats_tmp = data_tbl %>%
                             dplyr::filter(event_window == 1) %>%
-                            dplyr::group_by(firm_symbol) %>%
+                            dplyr::group_by(event_id) %>%
                             dplyr::mutate(day_index = dplyr::row_number()) %>%
                             dplyr::ungroup() %>%
-                            dplyr::left_join(fec_sigma, by = c("firm_symbol", "day_index")) %>%
+                            dplyr::left_join(fec_sigma, by = c("event_id", "day_index")) %>%
                             dplyr::mutate(standardized_abnormal_returns = abnormal_returns / fec_sigma)
 
                           # AAR & AAR Z Test
@@ -149,8 +152,8 @@ PatellZTest <- R6Class("PatellZTest",
                             dplyr::select(-sum_sar)
 
                           sd_caar = aar_caar_stats_tmp %>%
-                            dplyr::left_join(sd_asar, by = "firm_symbol") %>%
-                            dplyr::group_by(firm_symbol) %>%
+                            dplyr::left_join(sd_asar, by = "event_id") %>%
+                            dplyr::group_by(event_id) %>%
                             dplyr::mutate(csar = cumsum(dplyr::coalesce(standardized_abnormal_returns, 0)),
                                           n    = dplyr::row_number(),
                                           csar = csar / sqrt(n * .data$Q_i)) %>%
@@ -406,11 +409,14 @@ BMPTest <- R6Class("BMPTest",
                            x$statistics$sigma %||% NA_real_
                          }))
 
-                       # Standardize abnormal returns by model sigma
+                       # Standardize abnormal returns by model sigma.
+                       # Join on event_id, not firm_symbol: sigma is estimated
+                       # per event, and a firm may appear in several events. A
+                       # firm_symbol join is many-to-many and duplicates rows.
                        sar_data = data_tbl %>%
                          dplyr::filter(event_window == 1) %>%
-                         dplyr::left_join(model %>% dplyr::select(firm_symbol, sigma),
-                                          by = "firm_symbol") %>%
+                         dplyr::left_join(model %>% dplyr::select(event_id, sigma),
+                                          by = "event_id") %>%
                          dplyr::mutate(sar = abnormal_returns / sigma)
 
                        # BMP test: cross-sectional t-test of SARs
@@ -558,11 +564,13 @@ KolariPynnonenTest <- R6Class("KolariPynnonenTest",
                                        x$statistics$sigma %||% NA_real_
                                      }))
 
-                                   # Standardize abnormal returns by model sigma
+                                   # Standardize abnormal returns by model sigma.
+                                   # Join on event_id (see BMPTest): a firm_symbol
+                                   # join is many-to-many when a firm recurs.
                                    sar_data <- data_tbl %>%
                                      dplyr::filter(event_window == 1) %>%
-                                     dplyr::left_join(model %>% dplyr::select(firm_symbol, sigma),
-                                                      by = "firm_symbol") %>%
+                                     dplyr::left_join(model %>% dplyr::select(event_id, sigma),
+                                                      by = "event_id") %>%
                                      dplyr::mutate(sar = abnormal_returns / sigma)
 
                                    # --- BMP statistics (replicated from BMPTest) ---
@@ -603,14 +611,17 @@ KolariPynnonenTest <- R6Class("KolariPynnonenTest",
                                    # Compute average pairwise correlation of SARs from estimation window
                                    est_sar_data <- data_tbl %>%
                                      dplyr::filter(estimation_window == 1) %>%
-                                     dplyr::left_join(model %>% dplyr::select(firm_symbol, sigma),
-                                                      by = "firm_symbol") %>%
+                                     dplyr::left_join(model %>% dplyr::select(event_id, sigma),
+                                                      by = "event_id") %>%
                                      dplyr::mutate(sar = abnormal_returns / sigma)
 
-                                   # Pivot to wide: one column per firm
+                                   # Pivot to wide: one column per event. Events,
+                                   # not firms, are the cross-sectional units, so a
+                                   # firm recurring in several events yields distinct
+                                   # columns (a firm_symbol pivot would collide).
                                    est_sar_wide <- est_sar_data %>%
-                                     dplyr::select(relative_index, firm_symbol, sar) %>%
-                                     tidyr::pivot_wider(names_from = firm_symbol,
+                                     dplyr::select(relative_index, event_id, sar) %>%
+                                     tidyr::pivot_wider(names_from = event_id,
                                                         values_from = sar)
 
                                    # Compute correlation matrix of estimation-window SARs

--- a/tests/testthat/test_edge_cases.R
+++ b/tests/testthat/test_edge_cases.R
@@ -141,6 +141,7 @@ test_that("BMPTest handles NA abnormal returns", {
   }))
 
   model_tbl = tibble::tibble(
+    event_id = paste0("E", seq_len(n_firms)),
     firm_symbol = paste0("F", seq_len(n_firms)),
     model = lapply(seq_len(n_firms), function(i) {
       mm = MarketModel$new()
@@ -269,6 +270,7 @@ test_that("PatellZTest with very short estimation window (m <= 4)", {
   }))
 
   model_tbl = tibble::tibble(
+    event_id = paste0("E", 1:3),
     firm_symbol = paste0("F", 1:3),
     model = lapply(1:3, function(i) {
       mm = MarketModel$new()

--- a/tests/testthat/test_multi_event_statistics.R
+++ b/tests/testthat/test_multi_event_statistics.R
@@ -107,8 +107,11 @@ create_multi_event_model_data <- function(n_firms = 5, n_est = 50, n_ev = 11) {
     )
   }))
 
-  # Create model tibble matching the structure expected by PatellZTest/BMPTest
+  # Create model tibble matching the structure expected by PatellZTest/BMPTest.
+  # In the real pipeline the model tibble is keyed by event_id (one fit per
+  # event), so the fixture must carry event_id as well.
   model_tbl = tibble::tibble(
+    event_id = paste0("E", seq_len(n_firms)),
     firm_symbol = paste0("F", seq_len(n_firms)),
     model = lapply(seq_len(n_firms), function(i) {
       mm = MarketModel$new()
@@ -171,6 +174,7 @@ test_that("PatellZTest uses forecast-error-corrected sigma for standardization (
   fec_sigma_f1 = c(0.044, 0.040, 0.042)  # varies by day
   fec_sigma_f2 = c(0.088, 0.080, 0.084)
   model_tbl = tibble::tibble(
+    event_id = c("E1", "E2"),
     firm_symbol = c("F1", "F2"),
     model = list(
       list(statistics = list(sigma = 0.04, forecast_error_corrected_sigma = fec_sigma_f1)),
@@ -216,6 +220,7 @@ test_that("PatellZTest CSAR cumsum is per-firm with per-firm Q_i (GH #6)", {
 
   fec_sigma_val = 0.05
   model_tbl = tibble::tibble(
+    event_id = c("E1", "E2"),
     firm_symbol = c("F1", "F2"),
     model = lapply(1:2, function(i) {
       list(statistics = list(
@@ -470,4 +475,68 @@ test_that("PatellZTest k extraction handles NULL residuals gracefully", {
 
   result <- aar_tbl[[stat_name]][[1]]
   expect_true(all(!is.na(result$aar)))
+})
+
+
+# Regression test for GH #7: a firm appearing in multiple events must not
+# inflate n_events or the BMP/Patell statistics via a many-to-many sigma join.
+create_shared_firm_data <- function(n_events = 6, n_est = 50, n_ev = 11) {
+  set.seed(7)
+  # Only 2 distinct firms spread across n_events events -> firms recur.
+  data = do.call(rbind, lapply(seq_len(n_events), function(i) {
+    tibble::tibble(
+      event_id = paste0("E", i),
+      firm_symbol = paste0("F", ((i - 1) %% 2) + 1),  # F1, F2, F1, F2, ...
+      relative_index = c(seq(-n_est, -1), seq(0, n_ev - 1)),
+      index_returns = rnorm(n_est + n_ev, mean = 0.0003, sd = 0.015),
+      firm_returns = 0.001 + 1.2 * index_returns + rnorm(n_est + n_ev, sd = 0.01),
+      abnormal_returns = rnorm(n_est + n_ev, mean = 0.001, sd = 0.02),
+      event_window = c(rep(0, n_est), rep(1, n_ev)),
+      estimation_window = c(rep(1, n_est), rep(0, n_ev)),
+      event_date = c(rep(0, n_est), 1, rep(0, n_ev - 1))
+    )
+  }))
+
+  model_tbl = tibble::tibble(
+    event_id = paste0("E", seq_len(n_events)),
+    firm_symbol = paste0("F", ((seq_len(n_events) - 1) %% 2) + 1),
+    model = lapply(seq_len(n_events), function(i) {
+      mm = MarketModel$new()
+      mm$fit(data[data$event_id == paste0("E", i), ])
+      mm
+    })
+  )
+
+  list(data = data, model = model_tbl)
+}
+
+
+test_that("BMPTest does not inflate n_events when firms recur (GH #7)", {
+  md = create_shared_firm_data(n_events = 6)
+  result = BMPTest$new()$compute(md$data, md$model)
+
+  # 6 events, one observation per event at each relative day -> n_events == 6,
+  # not 6 * (#events sharing the firm).
+  expect_true(all(result$n_events == 6))
+  expect_true(all(result$n_valid_events == 6))
+  expect_true(all(is.finite(result$bmp_t)))
+})
+
+
+test_that("KolariPynnonenTest does not inflate n_events when firms recur (GH #7)", {
+  md = create_shared_firm_data(n_events = 6)
+  result = KolariPynnonenTest$new()$compute(md$data, md$model)
+
+  expect_true(all(result$n_events == 6))
+  expect_true(all(result$n_valid_events == 6))
+})
+
+
+test_that("PatellZTest does not inflate n_events when firms recur (GH #7)", {
+  md = create_shared_firm_data(n_events = 6)
+  result = PatellZTest$new()$compute(md$data, md$model)
+
+  expect_true(all(result$n_events == 6))
+  expect_true(all(result$n_valid_events == 6))
+  expect_true(all(is.finite(result$aar_z)))
 })


### PR DESCRIPTION
Fixes #7.

## Root cause

The multi-event `model` table holds **one row per event** (it is keyed by `event_id` — `calculate_statistics()` builds it from `.keys = c('event_id', 'group', 'firm_symbol')`). But `BMPTest`, `KolariPynnonenTest`, and `PatellZTest` joined/grouped on `firm_symbol`. When a firm appears in more than one event, `left_join(model, by = "firm_symbol")` is **many-to-many** and duplicates every return row once per event sharing that firm.

This inflated `n_events` by the average events-per-firm, and because the statistic is `sqrt(n_valid_events) * mean_sar / sd_sar`, it inflated `bmp_t` / `kp_t` / `aar_z` by ~`sqrt(events-per-firm)`. In the reporter's data, 9,255 events became 61,757 rows (×6.67), turning a true `bmp_t ≈ -3.0` into `-7.76`. `GeneralizedSignTest` was unaffected because it never joins `model`.

## Fix

Key all per-event quantities on `event_id`:

- **BMP / KP** — sigma joins → `event_id`
- **KP** — estimation-window correlation pivot → one column per `event_id` (events, not firms, are the cross-sectional units; a recurring firm would otherwise collapse into a list-column)
- **Patell** — estimation-window length, the forecast-error-corrected sigma vector + day indexing, the sigma join, and the cumulative-SAR grouping → `event_id`

## Why it slipped through

Every fixture used a strict 1-firm-↔-1-event mapping, so the join was never many-to-many in tests. Fixtures now carry `event_id` (matching the real pipeline) and three regression tests assert `n_events` is **not** inflated when firms recur across events.

## Validation

Ran the modified `BMPTest`/`PatellZTest`/`KolariPynnonenTest` `compute()` directly (R 4.6):

- 1:1 baseline still correct.
- Shared-firm case (2 firms across 6 events): `n_events == 6` for all three tests.
- Reverting only the BMP join reproduces `n_events = 18` (×3) with dplyr's many-to-many warning — confirming the regression tests catch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)